### PR TITLE
Fix ApiGateway package typo

### DIFF
--- a/back/api-gateway/src/main/java/com/neighbors/apigateway/ApiGatewayApplication.java
+++ b/back/api-gateway/src/main/java/com/neighbors/apigateway/ApiGatewayApplication.java
@@ -1,4 +1,4 @@
-package com.neighbors.apigateaway;
+package com.neighbors.apigateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;


### PR DESCRIPTION
## Summary
- rename `apigateaway` package folder to `apigateway`
- adjust package declaration in `ApiGatewayApplication`

## Testing
- `./gradlew test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686950455dbc83289e076f2ecff60ecf